### PR TITLE
fix: add generic CSR generator and OpenSSL interop

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2,3 +2,8 @@
 kind: service.CodeCov
 spec:
   targetThreshold: 45
+---
+kind: golang.Toolchain
+spec:
+    extraPackages:
+        - openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-21T15:18:29Z by kres 9f64b0d.
+# Generated on 2025-05-22T12:08:17Z by kres 9f64b0d.
 
 ARG TOOLCHAIN
 
@@ -19,7 +19,7 @@ RUN bunx markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ig
 
 # base toolchain image
 FROM --platform=${BUILDPLATFORM} ${TOOLCHAIN} AS toolchain
-RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
+RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev openssl
 
 # build tools
 FROM --platform=${BUILDPLATFORM} toolchain AS tools

--- a/x509/certificate.go
+++ b/x509/certificate.go
@@ -110,6 +110,8 @@ func NewCertificateFromCSRBytes(ca, key, csr []byte, setters ...Option) (*Certif
 		caKey, err = x509.ParsePKCS8PrivateKey(keyPemBlock.Bytes)
 	case PEMTypeECPrivate:
 		caKey, err = x509.ParseECPrivateKey(keyPemBlock.Bytes)
+	case PEMTypePrivate:
+		caKey, err = x509.ParsePKCS8PrivateKey(keyPemBlock.Bytes)
 	default:
 		err = fmt.Errorf("unsupported PEM block: %v", keyPemBlock.Type)
 	}

--- a/x509/certificate_key.go
+++ b/x509/certificate_key.go
@@ -211,6 +211,8 @@ func (p *PEMEncodedCertificateAndKey) GetKey() (any, error) {
 		return p.GetEd25519Key()
 	case PEMTypeECPrivate:
 		return p.GetECDSAKey()
+	case PEMTypePrivate:
+		return p.GetPrivateKey()
 	default:
 		return nil, fmt.Errorf("unsupported key type: %q", block.Type)
 	}
@@ -265,6 +267,21 @@ func (p *PEMEncodedCertificateAndKey) GetECDSAKey() (*ecdsa.PrivateKey, error) {
 	}
 
 	return ecdsaKey, nil
+}
+
+// GetPrivateKey parses generic PEM-encoded key.
+func (p *PEMEncodedCertificateAndKey) GetPrivateKey() (any, error) {
+	block, _ := pem.Decode(p.Key)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block")
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse key: %w", err)
+	}
+
+	return key, nil
 }
 
 // DeepCopy implements DeepCopy interface.

--- a/x509/constants.go
+++ b/x509/constants.go
@@ -13,6 +13,7 @@ const DefaultCertificateValidityDuration = 24 * time.Hour
 const (
 	PEMTypeRSAPrivate     = "RSA PRIVATE KEY"
 	PEMTypeRSAPublic      = "PUBLIC KEY"
+	PEMTypePrivate        = "PRIVATE KEY"
 	PEMTypeECPrivate      = "EC PRIVATE KEY"
 	PEMTypeECPublic       = "EC PUBLIC KEY"
 	PEMTypeEd25519Private = "ED25519 PRIVATE KEY"

--- a/x509/csr.go
+++ b/x509/csr.go
@@ -132,3 +132,17 @@ func NewECDSACSRAndIdentity(setters ...Option) (*CertificateSigningRequest, *PEM
 
 	return csr, identity, nil
 }
+
+// NewCSRAndIdentityFromCA generates a key matching the given CA certificate, and a CSR for the key.
+func NewCSRAndIdentityFromCA(caCrt *x509.Certificate, setters ...Option) (*CertificateSigningRequest, *PEMEncodedCertificateAndKey, error) {
+	switch caCrt.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return NewRSACSRAndIdentity(setters...)
+	case *ecdsa.PublicKey:
+		return NewECDSACSRAndIdentity(setters...)
+	case ed25519.PublicKey:
+		return NewEd25519CSRAndIdentity(setters...)
+	default:
+		return nil, nil, fmt.Errorf("unsupported CA certificate public key type: %T", caCrt.PublicKey)
+	}
+}

--- a/x509/csr_test.go
+++ b/x509/csr_test.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package x509_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	stdx509 "crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/crypto/x509"
+)
+
+func TestNewCSRAndIdentityFromCA(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct { //nolint:govet
+		name string
+
+		opts []x509.Option
+
+		expectedSignatureAlgorithm stdx509.SignatureAlgorithm
+		expectedKeyType            any
+	}{
+		{
+			name: "Ed25519",
+			opts: nil,
+
+			expectedSignatureAlgorithm: stdx509.PureEd25519,
+			expectedKeyType:            ed25519.PrivateKey(nil),
+		},
+		{
+			name: "RSA",
+			opts: []x509.Option{
+				x509.RSA(true),
+			},
+
+			expectedSignatureAlgorithm: stdx509.SHA512WithRSA,
+			expectedKeyType:            &rsa.PrivateKey{},
+		},
+		{
+			name: "ECDSA",
+			opts: []x509.Option{
+				x509.ECDSA(true),
+			},
+
+			expectedSignatureAlgorithm: stdx509.ECDSAWithSHA256,
+			expectedKeyType:            &ecdsa.PrivateKey{},
+		},
+		{
+			name: "ECDSA-SHA512",
+			opts: []x509.Option{
+				x509.ECDSASHA512(true),
+			},
+
+			expectedSignatureAlgorithm: stdx509.ECDSAWithSHA256,
+			expectedKeyType:            &ecdsa.PrivateKey{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ca, err := x509.NewSelfSignedCertificateAuthority(test.opts...)
+			require.NoError(t, err)
+
+			csr, identity, err := x509.NewCSRAndIdentityFromCA(ca.Crt, x509.Organization("test"), x509.CommonName("myself"))
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedSignatureAlgorithm, csr.X509CertificateRequest.SignatureAlgorithm)
+
+			key, err := identity.GetKey()
+			require.NoError(t, err)
+
+			assert.IsType(t, test.expectedKeyType, key)
+		})
+	}
+}


### PR DESCRIPTION
Add a generic CSR generator `NewCSRAndIdentityFromCA` which would guess the key type from the CA root certificate.

Add tests and fix OpenSSL interoperability - the library can consume and operate on keys and certificates generated by OpenSSL.