### PR TITLE
fix: enforce FIPS-140-3 compliance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-04T08:15:33Z by kres 232fe63.
+# Generated on 2025-07-02T13:16:58Z by kres 5128bc1-dirty.
 
 name: default
 concurrency:
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -76,6 +76,9 @@ jobs:
       - name: unit-tests-race
         run: |
           make unit-tests-race
+      - name: unit-tests-fips
+        run: |
+          make unit-tests-fips
       - name: coverage
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-07-02T13:16:08Z by kres 5128bc1-dirty.
+
+name: Lock old issues
+"on":
+  schedule:
+    - cron: 0 2 * * *
+permissions:
+  issues: write
+jobs:
+  action:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Lock old issues
+        uses: dessant/lock-threads@v5.0.1
+        with:
+          issue-inactive-days: "60"
+          log-output: "true"
+          process-only: issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-07-02T13:16:08Z by kres 5128bc1-dirty.
+
+name: Close stale issues and PRs
+"on":
+  schedule:
+    - cron: 30 1 * * *
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Close stale issues and PRs
+        uses: actions/stale@v9.1.0
+        with:
+          close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
+          days-before-issue-close: "5"
+          days-before-issue-stale: "180"
+          days-before-pr-close: "-1"
+          days-before-pr-stale: "45"
+          operations-per-run: "2000"
+          stale-issue-message: This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.
+          stale-pr-message: This PR is stale because it has been open 45 days with no activity.

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -7,3 +7,7 @@ kind: golang.Toolchain
 spec:
     extraPackages:
         - openssl
+---
+kind: golang.UnitTests
+spec:
+  runFIPS: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.15.1-labs
+# syntax = docker/dockerfile-upstream:1.16.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-22T12:08:17Z by kres 9f64b0d.
+# Generated on 2025-07-02T13:16:58Z by kres 5128bc1-dirty.
 
 ARG TOOLCHAIN
 
@@ -10,7 +10,7 @@ ARG TOOLCHAIN
 FROM scratch AS generate
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.2.13-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.2.15-alpine AS lint-markdown
 WORKDIR /src
 RUN bun i markdownlint-cli@0.45.0 sentences-per-line@0.3.0
 COPY .markdownlint.json .
@@ -70,6 +70,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=crypto/root/.cache/go-bui
 FROM base AS lint-govulncheck
 WORKDIR /src
 RUN --mount=type=cache,target=/root/.cache/go-build,id=crypto/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=crypto/go/pkg govulncheck ./...
+
+# runs unit-tests with strict FIPS-140 mode
+FROM base AS unit-tests-fips
+WORKDIR /src
+ARG TESTPKGS
+RUN --mount=type=cache,target=/root/.cache/go-build,id=crypto/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=crypto/go/pkg --mount=type=cache,target=/tmp,id=crypto/tmp GOFIPS140=latest GODEBUG=fips140=only go test -v -count 1 ${TESTPKGS}
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-race

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-14T13:00:06Z by kres 5ad3e5f.
+# Generated on 2025-07-02T13:16:58Z by kres 5128bc1-dirty.
 
 # common variables
 
@@ -21,12 +21,12 @@ PROTOBUF_GO_VERSION ?= 1.36.6
 GRPC_GO_VERSION ?= 1.5.1
 GRPC_GATEWAY_VERSION ?= 2.26.3
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.33.0
+GOIMPORTS_VERSION ?= 0.34.0
 GOMOCK_VERSION ?= 0.5.2
 DEEPCOPY_VERSION ?= v0.5.6
 GOLANGCILINT_VERSION ?= v2.1.6
 GOFUMPT_VERSION ?= v0.8.0
-GO_VERSION ?= 1.24.3
+GO_VERSION ?= 1.24.4
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
@@ -190,6 +190,10 @@ unit-tests:  ## Performs unit tests
 
 .PHONY: unit-tests-race
 unit-tests-race:  ## Performs unit tests with race detection enabled.
+	@$(MAKE) target-$@
+
+.PHONY: unit-tests-fips
+unit-tests-fips:  ## Performs unit tests with strict FIPS-140 mode.
 	@$(MAKE) target-$@
 
 .PHONY: lint-markdown

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/siderolabs/crypto
 
-go 1.22.1
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/x509/certificate_authority.go
+++ b/x509/certificate_authority.go
@@ -33,11 +33,17 @@ func NewSelfSignedCertificateAuthority(setters ...Option) (*CertificateAuthority
 		return nil, err
 	}
 
+	skID, err := NewSubjectKeyID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create subject key identifier: %w", err)
+	}
+
 	crt := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			Organization: opts.Organizations,
 		},
+		SubjectKeyId:          skID,
 		SignatureAlgorithm:    opts.SignatureAlgorithm,
 		NotBefore:             opts.NotBefore,
 		NotAfter:              opts.NotAfter,

--- a/x509/fips_test.go
+++ b/x509/fips_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package x509_test
+
+import (
+	"crypto/fips140"
+	"testing"
+)
+
+func TestFIPS(t *testing.T) {
+	t.Logf("FIPS mode enabled: %v", fips140.Enabled())
+}

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -31,6 +31,27 @@ func NewSerialNumber() (*big.Int, error) {
 	return sn, nil
 }
 
+// NewSubjectKeyID generates a Subject Key Identifier (SKID) for an X.509 certificate.
+func NewSubjectKeyID() ([]byte, error) {
+	// The SKID is typically the SHA-1 hash of the public key, but SHA-1 is not FIPS-140-3 compliant.
+	//
+	// From the RFC 5280, Section 4.2.1.2:
+	// The subject key identifier extension provides a means of identifying
+	// certificates that contain a particular public key.
+	//
+	// For CA certificates, subject key identifiers SHOULD be derived from
+	// the public key or a method that generates unique values.
+	// ....
+	//
+	// Other methods of generating unique numbers are also acceptable.
+	skid := make([]byte, 20) // SHA-1 produces a 20-byte hash
+	if _, err := rand.Read(skid); err != nil {
+		return nil, err
+	}
+
+	return skid, nil
+}
+
 // Hash calculates the SHA-256 hash of the Subject Public Key Information (SPKI)
 // object in an x509 certificate (in DER encoding). It returns the full hash as
 // a hex encoded string (suitable for passing to Set.Allow). See


### PR DESCRIPTION
See https://github.com/siderolabs/kres/pull/528

The problem was that stdlib generated subject key ID for CAs via SHA-1 which is not FIPS-140-3 compliant, so use a different method instead.