### PR TITLE
fix: remove code duplication and fix Ed255119 CA generation

### DIFF
--- a/x509/certificate_authority_test.go
+++ b/x509/certificate_authority_test.go
@@ -5,6 +5,7 @@
 package x509_test
 
 import (
+	"crypto/tls"
 	stdx509 "crypto/x509"
 	"testing"
 
@@ -64,6 +65,12 @@ func TestNewCertificateAuthority(t *testing.T) {
 			t.Parallel()
 
 			ca, err := x509.NewSelfSignedCertificateAuthority(test.opts...)
+			require.NoError(t, err)
+
+			crt, err := x509.NewCertificateAndKey(ca.Crt, ca.Key)
+			require.NoError(t, err)
+
+			_, err = tls.X509KeyPair(crt.Crt, crt.Key)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedPublicKeyAlgorithm, ca.Crt.PublicKeyAlgorithm)

--- a/x509/key.go
+++ b/x509/key.go
@@ -144,8 +144,10 @@ func (k *Ed25519Key) GetPublicKeyPEM() []byte {
 }
 
 // NewRSAKey generates an RSA key pair.
-func NewRSAKey() (*RSAKey, error) {
-	keyRSA, err := rsa.GenerateKey(rand.Reader, 4096)
+func NewRSAKey(opts ...Option) (*RSAKey, error) {
+	o := NewDefaultOptions(opts...)
+
+	keyRSA, err := rsa.GenerateKey(rand.Reader, o.Bits)
 	if err != nil {
 		return nil, err
 	}

--- a/x509/options.go
+++ b/x509/options.go
@@ -145,6 +145,13 @@ func OverrideSubject(f func(*pkix.Name)) Option {
 	}
 }
 
+// WithCopyOptions copies the provided options to the Options struct.
+func WithCopyOptions(opts *Options) Option {
+	return func(o *Options) {
+		*o = *opts // Copy the provided options into the current options
+	}
+}
+
 // NewDefaultOptions initializes the Options struct with default values.
 func NewDefaultOptions(setters ...Option) *Options {
 	opts := &Options{


### PR DESCRIPTION
Use already existing helpers to generate CA private key consistently (fixed for ECDSA and RSA).

Fix Ed25119 CA to return proper value for the 'Key', add a test which asserts we can convert CA to certificate.